### PR TITLE
Prevent blocks parsed as empty from being inserted

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { getDateForPage } from "logseq-dateutils";
-import { valueArray, valueZero, editValueArray } from "./index";
+import { valueArray, clearValueArray, editValueArray } from "./index";
 import "./App.css";
 import {
   data,
@@ -65,7 +65,7 @@ const App = () => {
     setIsSubmitted(false);
     setIsOpened(true);
     setFormValues([]);
-    valueZero();
+    clearValueArray();
     logseq.hideMainUI({ restoreEditingCursor: true });
   };
   let updateUI2 = () => {
@@ -107,7 +107,7 @@ const App = () => {
       replacementArray[name] = value;
     }
     triggerParse(data);
-    valueZero();
+    clearValueArray();
     insertProperlyTemplatedBlock2(blockUuid2, sibling, data);
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import "@logseq/libs";
-import { IBatchBlock, SettingSchemaDesc } from "@logseq/libs/dist/LSPlugin.user";
+import { BlockUUID, IBatchBlock, SettingSchemaDesc } from "@logseq/libs/dist/LSPlugin.user";
 import Sherlock from "sherlockjs";
 import { getDateForPage, getDateForPageWithoutBrackets } from "logseq-dateutils";
 import React from "react";
@@ -51,15 +51,15 @@ async function checkTemplate(uuid) {
   }
 }
 
-export var valueCount = 0;
+// export var valueCount = 0;
 export var valueArray: FormValues[] = [];
-export var currentValueCount = 0;
-export var currentValueArray = [];
+// export var currentValueCount = 0;
+// export var currentValueArray = [];
 
 export function editValueArray(value: FormValues[]) {
   valueArray = value;
 }
-export function valueZero() {
+export function clearValueArray() {
   valueArray = [];
 }
 async function main() {
@@ -69,7 +69,7 @@ async function main() {
   logseq.provideModel({
     async insertTemplatedBlock(e: any) {
       const { blockUuid, template, sibling, location } = e.dataset;
-      let blockUuid2: string = blockUuid
+      let blockUuid2: BlockUUID = blockUuid
       console.log(location)
       console.log(location.match(uuidRegex))
       if (location == "" || location == "undefined"){
@@ -195,7 +195,7 @@ async function main() {
         reset: true,
         slot,
         template: `
-            <button class="templater-btn" data-block-uuid="${payload.uuid}" data-sibling = ${sibling} data-template="${template}" data-title="${title}" data-location = "${location}"
+            <button class="templater-btn" data-block-uuid="${payload.uuid}" data-sibling=${sibling} data-template="${template}" data-title="${title}" data-location="${location}"
             data-on-click="insertTemplatedBlock">${title}</button>
            `,
       });
@@ -203,7 +203,7 @@ async function main() {
     if (type == ":smartblockInline") {
       if (!(await checkTemplate(payload.uuid))) {
         logseq.Editor.updateBlock(payload.uuid, "");
-        await insertProperlyTemplatedBlock(payload.uuid, template, title).then(
+        await insertProperlyTemplatedBlock(payload.uuid, template, title === "true").then(
           () => {
             logseq.Editor.updateBlock(payload.uuid, "");
           }

--- a/src/searchbar.tsx
+++ b/src/searchbar.tsx
@@ -87,13 +87,13 @@ const SearchBar: React.FC<{ blockID }> = ({ blockID }) => {
       insertProperlyTemplatedBlock(
         blockID,
         searchResults[highlightedResult],
-        "true"
+        true
       );
     }
     e.handled = true;
   }
   const insertBlocks = (e) => {
-    insertProperlyTemplatedBlock(blockID, e.target.id, "true");
+    insertProperlyTemplatedBlock(blockID, e.target.id, true);
   };
   const updateHighlight = () => {
     for (const x in searchResults) {


### PR DESCRIPTION
Addresses #35 by ignoring a block and it's children when the `content` of the block evaluates to `''`.

Also includes a prior commit with some code cleanup
- clearer variable/function names
- added types
- update deprecated function